### PR TITLE
Added the ability to get TOTP tokens

### DIFF
--- a/qubes-keepass.ini
+++ b/qubes-keepass.ini
@@ -5,7 +5,7 @@ smart_sort = True
 restricted =
 unrestricted =
 minimum_trust = 0
-view_totp = True
+view_totp = False
 
 [qubes.trust]
 trust_level_red = 1
@@ -22,11 +22,13 @@ title_length = 18
 folder_length = 18
 username_length = 18
 url_length = 0
+totp_length = 6
 
 [rofi.shortcuts]
 copy_url = Ctrl+U
 copy_password = Ctrl+c
 copy_username = Ctrl+b
+copy_totp = Ctrl+t
 
 [rofi.options]
 rofi_options_1 = -p

--- a/qubes-keepass.ini
+++ b/qubes-keepass.ini
@@ -5,6 +5,7 @@ smart_sort = True
 restricted =
 unrestricted =
 minimum_trust = 0
+view_totp = True
 
 [qubes.trust]
 trust_level_red = 1

--- a/qubes-keepass.py
+++ b/qubes-keepass.py
@@ -684,10 +684,10 @@ class Credential:
             value = self.url
 
         elif attribute == 13:
-            if self.totp is None:
+            if self.attributes.get('TOTP') is None:
                 return
             print(f'[+] Copying url of TOTP {self.title} to {qube}.')
-            value = self.totp
+            value = self.get_totp()
 
         perform_copy(qube, value)
 
@@ -796,7 +796,7 @@ class CredentialCollection:
     def __str__(self) -> str:
         '''
         The string representiation of a CredentialCollection is a formatted list
-        that can be displayed within rogi.
+        that can be displayed within rofi.
 
         Parameters:
             credentials         list of credentials to display
@@ -807,7 +807,6 @@ class CredentialCollection:
         formatted = ''
 
         for credential in self.credentials:
-
             line = ''
             folder = credential.path.parent.name or 'Root'
 
@@ -858,6 +857,7 @@ class CredentialCollection:
         mappings = ['-kb-custom-1', Config.get('copy_password')]
         mappings += ['-kb-custom-2', Config.get('copy_username')]
         mappings += ['-kb-custom-3', Config.get('copy_url')]
+        mappings += ['-kb-custom-4', Config.get('copy_totp')]
 
         print('[+] Starting rofi.')
         process = subprocess.Popen(['rofi'] + Config.get_rofi_options() + ['-mesg', rofi_mesg] + mappings,
@@ -930,7 +930,7 @@ def main() -> None:
         print("[-] The configuration options 'restricted' and 'unrestricted' are mutually exclusive.")
         print('[-] Configure only one of them and leave the other empty to continue.')
         return
-    
+
     try:
         service = Secret.Service.get_sync(Secret.ServiceFlags.OPEN_SESSION | Secret.ServiceFlags.LOAD_COLLECTIONS)
 


### PR DESCRIPTION
Hi all,

I have fixed the quick 'hack' and now added the ability to Opt-In to get a TOTP token.
Furthermore, it was not possible to get the new token with get_attributes() after the time has run out.
I also tried reloading the whole database which did not seem to work.
As such, I had to include a library which generates the TOTP when pressing Ctrl + t.

The feature can be activated by setting view_totp = True.

The following library is needed to generate the TOTP: `pyotp`
It is to note, that the library is only needed when copying a TOTP token and would not be needed if deactivated. (Check source code)

Cheers