### PR TITLE
Unbind secondary clipboard binding

### DIFF
--- a/qubes-keepass.py
+++ b/qubes-keepass.py
@@ -818,6 +818,7 @@ class CredentialCollection:
         mappings = ['-kb-custom-1', Config.get('copy_password')]
         mappings += ['-kb-custom-2', Config.get('copy_username')]
         mappings += ['-kb-custom-3', Config.get('copy_url')]
+        mappings += ['-kb-secondary-copy', '']
 
         print('[+] Starting rofi.')
         process = subprocess.Popen(['rofi'] + Config.get_rofi_options() + ['-mesg', rofi_mesg] + mappings,


### PR DESCRIPTION
In fedora 41, Ctrl+C seems to be bound per default in rofi. This binding blocks the default copy-password binding of qubes-keepass. This commit unsets the default binding to make Ctrl+C available again.